### PR TITLE
Connect NVS and NCH exchange to the shared Faucet interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,11 @@ COPY . /var/www/html
 RUN sed -ri 's#/var/www/html#/var/www/html/web#g' /etc/apache2/sites-available/000-default.conf \
  && sed -ri 's#/var/www/html#/var/www/html/web#g' /etc/apache2/apache2.conf
 
+# Writable portal lock and default SQLite storage.
+RUN mkdir -p /var/www/html/data \
+ && chown -R www-data:www-data /var/www/html/data \
+ && printf 'default_socket_timeout=15\n' > /usr/local/etc/php/conf.d/portal.ini
+
 # Enable Apache mod_rewrite if needed
 RUN a2enmod rewrite
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -5,10 +5,9 @@ return [
         'host' => 'localhost',
         'port' => '6660',
         'wallets' => [
-            '2021_12_02_fdgh.wlt' => '123456789$',
-            '2022_06_15_fada.wlt' => 'qwerty'
+            'example-wallet.wlt' => '' // Set the actual password only in config.php.
         ],
-        'main_wallet_id' => '2021_12_02_fdgh.wlt',
+        'main_wallet_id' => 'example-wallet.wlt',
         'prefix' => 'http://',
         /** Generate new address for new slot or use existing one */
         'gen_address' => true
@@ -20,6 +19,7 @@ return [
         'password' => ''
     ],
     'db' => [
+        'filename' => '../data/exchange.db',
         'host' => 'localhost',
         'user' => '',
         'password' => '',

--- a/decoders/ExchangeFormDecoder.php
+++ b/decoders/ExchangeFormDecoder.php
@@ -15,9 +15,11 @@ class ExchangeFormDecoder implements iDecoder {
 
     public function encodeValue(array $fields): string
     {
+        $title = htmlspecialchars($fields['title'], ENT_QUOTES | ENT_XML1, 'UTF-8');
+        $url = htmlspecialchars($fields['url'], ENT_QUOTES | ENT_XML1, 'UTF-8');
         return <<<WORM
 <worm>
-    <token type="ness-exchange-v1-v2" title="$fields[title]" url="$fields[url]"/>
+    <exchange type="ness-exchange-v1-v2" title="$title" url="$url"/>
 </worm> 
 WORM;
     }
@@ -26,11 +28,20 @@ WORM;
     {
         $xmlString = preg_replace("/<!--.+?-->/i", '', $value);
         $xmlString = preg_replace('/”/i', '"', $xmlString);
-        $xmlObject = simplexml_load_string($xmlString);
+        if (stripos($xmlString, '<!DOCTYPE') !== false || stripos($xmlString, '<!ENTITY') !== false) {
+            throw new \InvalidArgumentException('Invalid exchange descriptor');
+        }
+        $xmlObject = simplexml_load_string($xmlString, 'SimpleXMLElement', LIBXML_NONET);
+        if ($xmlObject === false) { throw new \InvalidArgumentException('Invalid exchange descriptor'); }
+        // Accept the historical encoder's token element as well as exchange.
+        $entry = isset($xmlObject->exchange) ? $xmlObject->exchange : $xmlObject->token;
 
-        $title = (string) $xmlObject->exchange['title'];
-        $url = (string) $xmlObject->exchange['url'];
+        $title = (string) $entry['title'];
+        $url = (string) $entry['url'];
 
+        if (!filter_var($url, FILTER_VALIDATE_URL) || !in_array(parse_url($url, PHP_URL_SCHEME), ['https', 'http'], true)) {
+            throw new \InvalidArgumentException('Invalid exchange service URL');
+        }
         return [
             "url" => $url,
             "title" => $title,

--- a/decoders/ExchangeFormTokenDecoder.php
+++ b/decoders/ExchangeFormTokenDecoder.php
@@ -15,9 +15,11 @@ class ExchangeFormTokenDecoder implements iDecoder {
 
     public function encodeValue(array $fields): string
     {
+        $address = htmlspecialchars($fields['address'], ENT_QUOTES | ENT_XML1, 'UTF-8');
+        $payAddress = htmlspecialchars($fields['pay_address'], ENT_QUOTES | ENT_XML1, 'UTF-8');
         return <<<WORM
 <worm>
-    <token type="ness-exchange-v1-v2" address="$fields[address]" pay_address="$fields[pay_address]"/>
+    <token type="ness-exchange-v1-v2" address="$address" pay_address="$payAddress"/>
 </worm> 
 WORM;
     }
@@ -26,7 +28,11 @@ WORM;
     {
         $xmlString = preg_replace("/<!--.+?-->/i", '', $value);
         $xmlString = preg_replace('/”/i', '"', $xmlString);
-        $xmlObject = simplexml_load_string($xmlString);
+        if (stripos($xmlString, '<!DOCTYPE') !== false || stripos($xmlString, '<!ENTITY') !== false) {
+            throw new \InvalidArgumentException('Invalid exchange token');
+        }
+        $xmlObject = simplexml_load_string($xmlString, 'SimpleXMLElement', LIBXML_NONET);
+        if ($xmlObject === false || !isset($xmlObject->token)) { throw new \InvalidArgumentException('Invalid exchange token'); }
 
         $address = (string) $xmlObject->token['address'];
         $pay_address = (string) $xmlObject->token['pay_address'];

--- a/docs/PORTAL.md
+++ b/docs/PORTAL.md
@@ -1,0 +1,11 @@
+# Shared Faucet and Exchange portal
+
+Use this branch with Faucet branch `codex/unified-faucet-countdown` in `Jeff-Bouchard/Faucet`.
+
+The unified interface is served by Faucet. This repository supplies `web/api.php` for existing NVS registration and NCH exchange slot creation, status, and payment processing. Both services must be served under one HTTPS origin. Keep NVS-exchange at the public root and proxy Faucet under `/faucet/`; set `FAUCET_PORTAL_URL=/faucet/` here and `EXCHANGE_API_PATH=/api.php` in Faucet. See Faucet `docs/INTEGRATION.md` and `deploy/nginx.conf.example` for the full setup and operational limits.
+
+The API uses a separate strict HttpOnly session cookie and CSRF header, preserves existing payment wallet adapters, serializes its own mutations, and recovers repeated creates within the session. It uses the current `worm:exchange:ness_exchange_v1_v2` service descriptor, with both historical descriptor element spellings supported. The descriptor encoder emits `<exchange>` consistently and escapes XML attributes. No faucet time token is converted into a WORM token.
+
+Keep `data/` writable for the portal lock. Configure `db.filename` with the existing SQLite path. The sample now includes `../data/exchange.db`, but do not replace an existing database. Set `COOKIE_SECURE=1` behind HTTPS and a finite PHP default_socket_timeout. The legacy record editor and status URLs remain available and retain their previous access model.
+
+Run `php tests/run.php` with PHP sodium/PDO SQLite/cURL/SimpleXML available. Real exchange processing also requires the configured Emercoin and NESS RPC nodes and the resolved external exchange service. A successful unit test is not evidence of a funded or healthy live exchange.

--- a/lib/Container.php
+++ b/lib/Container.php
@@ -10,6 +10,8 @@ require_once __DIR__ . '/../lib/Sqlite.php';
 require_once __DIR__ . '/../lib/Emercoin.php';
 require_once __DIR__ . '/../wallets/Emercoin.php';
 require_once __DIR__ . '/../wallets/NessGen.php';
+require_once __DIR__ . '/../wallets/Ness.php';
+require_once __DIR__ . '/../wallets/NCH.php';
 require_once __DIR__ . '/../wallets/NchGen.php';
 
 use decoders\ExchangeFormDecoder;

--- a/lib/Http.php
+++ b/lib/Http.php
@@ -1,0 +1,65 @@
+<?php
+namespace lib;
+
+final class Http
+{
+    public static function session(string $name): void
+    {
+        ini_set('display_errors', '0');
+        ini_set('session.use_strict_mode', '1');
+        ini_set('session.use_only_cookies', '1');
+        session_name($name);
+        session_set_cookie_params([
+            'lifetime' => 0, 'path' => '/',
+            'secure' => (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || getenv('COOKIE_SECURE') === '1',
+            'httponly' => true, 'samesite' => 'Strict',
+        ]);
+        if (!session_start()) {
+            throw new \RuntimeException('Session unavailable');
+        }
+        if (empty($_SESSION['csrf'])) {
+            $_SESSION['csrf'] = bin2hex(random_bytes(32));
+        }
+        header('Cache-Control: no-store, private');
+        header('X-Content-Type-Options: nosniff');
+        header('Referrer-Policy: no-referrer');
+    }
+
+    public static function input(): array
+    {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            self::json(['error' => 'Use POST for this action.'], 405);
+        }
+        if (($_SERVER['HTTP_SEC_FETCH_SITE'] ?? '') === 'cross-site') {
+            self::json(['error' => 'Cross-site request rejected.'], 403);
+        }
+        if (!hash_equals($_SESSION['csrf'], $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '')) {
+            self::json(['error' => 'Refresh the page and try again.'], 403);
+        }
+        $raw = file_get_contents('php://input', false, null, 0, 16385);
+        if (strlen($raw) > 16384) {
+            self::json(['error' => 'Request is too large.'], 413);
+        }
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            self::json(['error' => 'Invalid request.'], 400);
+        }
+        return $data;
+    }
+
+    public static function text(array $data, string $key, int $max): string
+    {
+        if (!isset($data[$key]) || !is_string($data[$key]) || strlen($data[$key]) > $max) {
+            throw new \InvalidArgumentException('Invalid ' . str_replace('_', ' ', $key) . '.');
+        }
+        return trim($data[$key]);
+    }
+
+    public static function json(array $data, int $status = 200): void
+    {
+        http_response_code($status);
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode($data, JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES);
+        exit;
+    }
+}

--- a/lib/JsonRpcClient.php
+++ b/lib/JsonRpcClient.php
@@ -137,6 +137,8 @@ class JsonRpcClient {
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $this->url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 15);
 		curl_setopt($ch, CURLOPT_HTTPHEADER, array('content-type: application/json;charset=\"utf-8\"'));
 		curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, $request);

--- a/lib/Ness.php
+++ b/lib/Ness.php
@@ -78,7 +78,6 @@ class Ness {
 
   public function createAddr(): string 
   {
-    echo 2;
     $responce = file_get_contents($this->prefix . $this->host . ":" . $this->port . "/api/v1/csrf");
 
     if (empty($responce)) {
@@ -96,6 +95,8 @@ class Ness {
 
     $ch = curl_init($this->prefix . $this->host . ":" . $this->port . "/api/v1/wallet/newAddress");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 15);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array('X-CSRF-Token: '.$token));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $fields);
@@ -130,6 +131,8 @@ class Ness {
 
     $ch = curl_init($this->prefix . $this->host . ":" . $this->port . "/api/v1/wallet/newAddress");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 15);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array('X-CSRF-Token: '.$token));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $fields);
@@ -242,6 +245,8 @@ BODY;
 
     $ch = curl_init($this->prefix . $this->host . ":" . $this->port . "/api/v1/wallet/transaction");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 15);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'X-CSRF-Token: '.$token));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
@@ -271,6 +276,8 @@ BODY;
 
     $ch = curl_init($this->prefix . $this->host . ":" . $this->port . "/api/v1/injectTransaction");
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 15);
     curl_setopt($ch, CURLOPT_POST, true);
     curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json', 'X-CSRF-Token: '.$token));
     curl_setopt($ch, CURLOPT_POSTFIELDS, $body);

--- a/lib/Slots.php
+++ b/lib/Slots.php
@@ -23,7 +23,7 @@ class Slots {
 
     public function createSlot(string $key, string $value, string $address = '', $days = 100): string
     {
-        $slot_id = md5(rand(10000, 99999) . time());
+        $slot_id = bin2hex(random_bytes(16));
         $daysx100 = ceil($days / 100);
         
         $addr = [];

--- a/lib/Sqlite.php
+++ b/lib/Sqlite.php
@@ -10,7 +10,9 @@ class Sqlite implements iSlotDatabase {
 
     public function __construct($db_filename)
     {
-        $this->connection = new \PDO("sqlite:" . __DIR__ . '/' . $db_filename);
+        $path = substr($db_filename, 0, 1) === '/' ? $db_filename : __DIR__ . '/' . $db_filename;
+        $this->connection = new \PDO("sqlite:" . $path, null, null, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+        $this->connection->exec("PRAGMA busy_timeout = 5000");
 
         $sql = <<<SQL
             CREATE TABLE IF NOT EXISTS `slots` (

--- a/modules/ExchangeForm.php
+++ b/modules/ExchangeForm.php
@@ -35,7 +35,7 @@ class ExchangeForm extends BaseModule {
 
     public function pingExchangeForm(): bool
     {
-        $data = file_get_contents($this->url);
+        $data = file_get_contents($this->url, false, stream_context_create(['http' => ['timeout' => 10]]));
         $data = json_decode($data, true);
         return isset($data['status']);
     }
@@ -47,7 +47,7 @@ class ExchangeForm extends BaseModule {
 
     private function loadToken(string $addr, string $payAddr): array
     {
-        $token = file_get_contents($this->url . "?address=$addr&pay_address=$payAddr");
+        $token = file_get_contents($this->url . (strpos($this->url, '?') === false ? '?' : '&') . http_build_query(['address' => $addr, 'pay_address' => $payAddr]), false, stream_context_create(['http' => ['timeout' => 10]]));
         return json_decode($token, true);
     }
 

--- a/readme.md
+++ b/readme.md
@@ -23,3 +23,6 @@ List addresses for default (main_wallet_id in config.php) or selected ness walle
 `php exec/new-addr.php [wallet-filename] [new addresses count]`
 
 Make new address or addresses
+## Shared Faucet portal
+
+See [portal integration](docs/PORTAL.md) for the new JSON API and the matching Faucet interface. Run `php tests/run.php` before deployment.

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,31 @@
+<?php
+require_once __DIR__ . '/../decoders/ExchangeFormDecoder.php';
+require_once __DIR__ . '/../decoders/ExchangeFormTokenDecoder.php';
+require_once __DIR__ . '/../lib/Sqlite.php';
+require_once __DIR__ . '/../lib/Container.php';
+$count = 0;
+function expect($condition, string $message): void {
+    global $count;
+    if (!$condition) { throw new RuntimeException($message); }
+    $count++; echo "PASS $message\n";
+}
+$descriptor = new decoders\ExchangeFormDecoder();
+$fields = ['title' => 'NESS & NCH "exchange"', 'url' => 'https://exchange.example/api?one=1&two=2'];
+expect($descriptor->decodeValue($descriptor->encodeValue($fields)) == $fields, 'exchange descriptor round trip and XML escaping');
+expect($descriptor->decodeValue('<worm><token title="Legacy" url="https://exchange.example/"/></worm>')['title'] === 'Legacy', 'historical descriptor element supported');
+$decoder = new decoders\ExchangeFormTokenDecoder();
+$fields = ['address' => 'A&B"C', 'pay_address' => 'DEF'];
+expect($decoder->decodeValue($decoder->encodeValue($fields)) === $fields, 'exchange token XML attributes safely round trip');
+try { $descriptor->decodeValue('<!DOCTYPE worm [<!ENTITY t SYSTEM "file:///etc/passwd">]><worm/>'); expect(false, 'DTD rejected'); }
+catch (InvalidArgumentException $error) { expect(true, 'DTD rejected'); }
+expect(class_exists('wallets\\Ness') && class_exists('wallets\\NCH'), 'generated-address wallet classes load');
+$file = tempnam(sys_get_temp_dir(), 'exchange-test-');
+try {
+    $db = new lib\Sqlite($file);
+    expect($db->createSlot('test:name', 'hello', '{}', '', str_repeat('a', 32)), 'slot created with absolute SQLite path');
+    $slot = $db->getSlot(str_repeat('a', 32));
+    expect($slot['name'] === 'test:name' && $slot['status'] === 'GENERATED', 'slot reads back with existing schema');
+    $db->setSlotPayed($slot['slot_id']);
+    expect($db->getSlot($slot['slot_id'])['status'] === 'PAYED', 'legacy payment status persists');
+} finally { unset($db); unlink($file); }
+echo "$count checks passed\n";

--- a/wallets/Ness.php
+++ b/wallets/Ness.php
@@ -15,7 +15,7 @@ class Ness implements IWallet {
     {
         $config = require __DIR__ . '/../config/config.php';
         $ness = $config['ness'];
-        $this->ness = new Privateness($ness['host'], (int) $ness['port'], $ness['wallet_id'], $ness['password'], $ness['prefix']);
+        $this->ness = new Privateness($ness['host'], (int) $ness['port'], $ness['wallets'], $ness['main_wallet_id'], $ness['prefix']);
     }
 
     public function getMinSum(int $daysx100): float

--- a/web/api.php
+++ b/web/api.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/../lib/Http.php';
+use lib\Http;
+
+function portalSlot(string $kind, string $id, $slots, $exchange): array {
+    $slot = $kind === 'exchange' ? $exchange->showSlot($id) : $slots->showSlot($id);
+    if (!$slot) { throw new InvalidArgumentException('Request not found.'); }
+    $result = ['slot_id' => $id, 'name' => $slot['name'], 'status' => strtolower($slot['status']), 'payments' => $slot['addr']];
+    foreach (['address', 'pay_address', 'gen_address', 'hours', 'recieve', 'error'] as $key) {
+        if (isset($slot[$key])) { $result[$key] = $slot[$key]; }
+    }
+    return $result;
+}
+
+try {
+    Http::session('privateness_exchange');
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        Http::json(['csrf' => $_SESSION['csrf']]);
+    }
+    $input = Http::input();
+    $action = Http::text($input, 'action', 16);
+    $kind = Http::text($input, 'kind', 16);
+    if (!in_array($kind, ['nvs', 'exchange'], true) || !in_array($action, ['create', 'status'], true)) {
+        throw new InvalidArgumentException('Unknown action.');
+    }
+    require_once __DIR__ . '/../lib/Container.php';
+    require_once __DIR__ . '/../modules/ExchangeForm.php';
+    // All portal slot creation/payment checks serialize across PHP sessions.
+    $lock = fopen(__DIR__ . '/../data/portal.lock', 'c');
+    if (!$lock || !flock($lock, LOCK_EX)) { throw new RuntimeException('Unable to lock exchange'); }
+    $exchange = $kind === 'exchange' ? lib\Container::createExchangeForm() : null;
+    $slots = $exchange ? $exchange->getSlot() : lib\Container::createSlots();
+    if ($action === 'status') {
+        $id = Http::text($input, 'slot_id', 64);
+        if (!preg_match('/^[a-f0-9]{32,64}$/D', $id)) { throw new InvalidArgumentException('Invalid request reference.'); }
+        if (!isset($_SESSION['portal_slots'][$kind][$id])) {
+            Http::json(['error' => 'This request belongs to another session. Use its original status page.'], 403);
+        }
+        if (!empty($input['process'])) { $slots->processSlot($id); }
+        Http::json(portalSlot($kind, $id, $slots, $exchange));
+    }
+    if ($kind === 'exchange') {
+        $address = Http::text($input, 'address', 64);
+        $payAddress = Http::text($input, 'pay_address', 64);
+        foreach ([$address, $payAddress] as $value) {
+            if (!preg_match('/^[1-9A-HJ-NP-Za-km-z]{20,64}$/D', $value)) { throw new InvalidArgumentException('Enter valid NESS addresses.'); }
+        }
+        $fields = ['address' => $address, 'pay_address' => $payAddress];
+        $existing = $exchange->findSlot($fields);
+        $fingerprint = hash('sha256', json_encode($fields));
+    } else {
+        $name = Http::text($input, 'name', 512);
+        $value = Http::text($input, 'value', 10240);
+        $owner = Http::text($input, 'owner', 64);
+        $days = filter_var($input['days'] ?? null, FILTER_VALIDATE_INT, ['options' => ['min_range' => 100, 'max_range' => 3650]]);
+        if ($name === '' || $value === '' || !$days || preg_match('/[\\x00-\\x1f\\x7f]/', $name)) { throw new InvalidArgumentException('Check the record name, value, and duration.'); }
+        if ($owner !== '' && !preg_match('/^[1-9A-HJ-NP-Za-km-z]{20,64}$/D', $owner)) { throw new InvalidArgumentException('Enter a valid EMC owner address.'); }
+        $existing = $slots->findSlot($name);
+        $fingerprint = hash('sha256', json_encode([$name, $value, $owner, $days]));
+    }
+    if (isset($_SESSION['portal_requests'][$fingerprint])) {
+        Http::json(portalSlot($kind, $_SESSION['portal_requests'][$fingerprint], $slots, $exchange));
+    }
+    if ($existing) { throw new InvalidArgumentException('A request already exists for this record. Use its original status page.'); }
+    if (time() - $slots->lastSlotTime() < 30) {
+        header('Retry-After: 30');
+        Http::json(['error' => 'Please wait 30 seconds between new exchange requests.'], 429);
+    }
+    if ($kind === 'exchange') {
+        if (!$exchange->pingExchangeForm()) { throw new RuntimeException('Exchange is unavailable'); }
+        if ($exchange->locateSlot($fields)) { throw new InvalidArgumentException('This exchange request is already registered.'); }
+        $id = $exchange->createSlot($fields);
+    } else {
+        if ($slots->locateSlot($name)) { throw new InvalidArgumentException('This record is already registered. Use the existing record editor.'); }
+        $id = $slots->createSlot($name, $value, $owner, $days);
+    }
+    $_SESSION['portal_requests'][$fingerprint] = $id;
+    $_SESSION['portal_slots'][$kind][$id] = true;
+    Http::json(portalSlot($kind, $id, $slots, $exchange), 201);
+} catch (InvalidArgumentException $error) {
+    Http::json(['error' => $error->getMessage()], 400);
+} catch (Throwable $error) {
+    Http::json(['error' => 'The exchange is unavailable or awaiting a network response. Retry the same request to recover it.'], 503);
+}

--- a/web/index.php
+++ b/web/index.php
@@ -1,5 +1,11 @@
 <?php
 ini_set('display_errors', false);
+// Optional shared portal entry; legacy POST and editor paths remain available.
+$portal = getenv('FAUCET_PORTAL_URL');
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && $portal && preg_match('~^(https://[^\s]+|/(?!/)[^\s]*)$~D', $portal)) {
+    header('Location: ' . $portal . '#nvs', true, 302);
+    exit;
+}
 require __DIR__ . '/../lib/Container.php';
 
 use lib\Container;


### PR DESCRIPTION
The shared Faucet interface needs JSON access to NVS registration, NCH exchange requests, payment instructions, and status updates.

This change adds a session-owned, CSRF-protected API around the existing slot and wallet services. Repeated creates recover the same request; portal mutations serialize and retain the 30-second creation cooldown. FAUCET_PORTAL_URL optionally makes the shared interface the public entry point while preserving legacy editor/status routes.

It also fixes integration blockers: missing wallet class imports, the NESS wallet constructor signature, descriptor encoder/decoder element mismatch, missing sample SQLite filename, debug output corrupting JSON, and unbounded service calls. XML attributes are escaped, DTDs rejected, slot IDs use random_bytes, and password-like sample values are replaced with empty placeholders.

Pair with `codex/unified-faucet-countdown` in Jeff-Bouchard/Faucet. See docs/PORTAL.md and the Faucet integration guide.

Validation: 8 exchange PHP checks and 24 cross-service HTTP integration checks passed using native PHP 8.3.6, temporary SQLite databases, and simulated NESS/Emercoin/exchange services. All 58 PHP files across both repositories linted successfully.

Limits: production RPC nodes, live liquidity, Docker builds, and browser/device behavior were not tested. Legacy exchange authorization and processing outside the new portal retain their existing model; this is not a full exchange security audit.